### PR TITLE
feat(eip712): add EIP-712 signature request buttons to playground (WALLET-1254)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,7 @@ const makeUnsupportedTypedData = (): SignTypedDataParams['typedData'] => ({
   types: {
     Permit: [
       { name: 'owner', type: 'address' },
+      // bytes16 is intentionally unsupported, to exercise the error path
       { name: 'nonce', type: 'bytes16' }
     ]
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ const makePermitTypedData = (): SignTypedDataParams['typedData'] => ({
   domain: {
     name: 'MyDapp',
     version: '1',
-    chain_name: 'casper',
+    chain_name: CasperNetworkName.Testnet,
     contract_package_hash: SAMPLE_CONTRACT_PACKAGE_HASH
   },
   types: {
@@ -84,7 +84,7 @@ const makeUnsupportedTypedData = (): SignTypedDataParams['typedData'] => ({
   domain: {
     name: 'MyDapp',
     version: '1',
-    chain_name: 'casper',
+    chain_name: CasperNetworkName.Testnet,
     contract_package_hash: SAMPLE_CONTRACT_PACKAGE_HASH
   },
   types: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import logo from './logo.svg';
 import { Button } from '@mui/material';
 import styled from '@emotion/styled';
-import { useWalletService } from './wallet-service';
+import { useWalletService, SignTypedDataParams } from './wallet-service';
 import {
   makeCasperMarketListBuilder,
   makeContractWithListsBuilder,
@@ -29,7 +29,7 @@ import {
   NativeUndelegateBuilder,
   PublicKey,
   Transaction,
-  CasperNetworkName, HexBytes
+  CasperNetworkName,
 } from 'casper-js-sdk';
 
 const Container = styled('div')({
@@ -55,6 +55,51 @@ const RowWrap = styled(Row)({
   flexWrap: 'wrap'
 });
 
+const SAMPLE_CONTRACT_PACKAGE_HASH =
+  '7fd113f60890c8ea77daf90880852f544b618c62315bcfd2dd93304c389fa19d';
+
+const makePermitTypedData = (): SignTypedDataParams['typedData'] => ({
+  domain: {
+    name: 'MyDapp',
+    version: '1',
+    chain_name: 'casper',
+    contract_package_hash: SAMPLE_CONTRACT_PACKAGE_HASH
+  },
+  types: {
+    Permit: [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+      { name: 'value', type: 'uint256' }
+    ]
+  },
+  primaryType: 'Permit',
+  message: {
+    owner: '0x1111111111111111111111111111111111111111',
+    spender: '0x2222222222222222222222222222222222222222',
+    value: '1000'
+  }
+});
+
+const makeUnsupportedTypedData = (): SignTypedDataParams['typedData'] => ({
+  domain: {
+    name: 'MyDapp',
+    version: '1',
+    chain_name: 'casper',
+    contract_package_hash: SAMPLE_CONTRACT_PACKAGE_HASH
+  },
+  types: {
+    Permit: [
+      { name: 'owner', type: 'address' },
+      { name: 'nonce', type: 'bytes16' }
+    ]
+  },
+  primaryType: 'Permit',
+  message: {
+    owner: '0x1111111111111111111111111111111111111111',
+    nonce: '0x00000000000000000000000000000000'
+  }
+});
+
 function App() {
   const {
     logs,
@@ -63,6 +108,7 @@ function App() {
     disconnect,
     sign,
     signMessage,
+    signTypedData,
     switchAccount,
     getVersion,
     isSiteConnected,
@@ -205,6 +251,31 @@ function App() {
           alert('Sign cancelled');
         } else {
           alert('Sign successful: ' + JSON.stringify(res.signature, null, 2));
+        }
+      })
+      .catch(err => {
+        alert('Error: ' + err);
+        throw err;
+      });
+  };
+
+  const handleSignTypedData = (
+    params: SignTypedDataParams,
+    accountPublicKey: string
+  ) => {
+    signTypedData(params, accountPublicKey)
+      .then(res => {
+        if (!res || res.cancelled) {
+          alert('Sign cancelled');
+        } else if (res.error) {
+          alert('Sign failed: ' + res.error + ' (' + res.errorCode + ')');
+        } else {
+          log('EIP-712 sign result', {
+            signature: res.signature,
+            digest: res.digest,
+            publicKey: res.publicKey,
+            hashArtifacts: res.hashArtifacts
+          });
         }
       })
       .catch(err => {
@@ -994,6 +1065,63 @@ Decrypted message - ${decryptedResp.decryptedMessage}
               }}
             >
               Decrypt (specify signing key)
+            </Button>
+          </div>
+        }
+      </Row>
+
+      <Row>
+        {
+          <div>
+            <div style={{ textAlign: 'center' }}>
+              EIP-712 SIGNATURE REQUEST SCENARIOS
+            </div>
+            <Button
+              variant='text'
+              onClick={() => {
+                handleSignTypedData({ typedData: makePermitTypedData() }, signingKey);
+              }}
+            >
+              Sign Typed Data (Permit)
+            </Button>
+            <Button
+              variant='text'
+              onClick={() => {
+                const key = prompt('Enter signing public key hex');
+
+                if (!key) {
+                  return;
+                }
+
+                handleSignTypedData({ typedData: makePermitTypedData() }, key);
+              }}
+            >
+              Sign Typed Data (specify signing key)
+            </Button>
+            <Button
+              variant='text'
+              onClick={() => {
+                handleSignTypedData(
+                  {
+                    typedData: makePermitTypedData(),
+                    options: { returnHashArtifacts: true }
+                  },
+                  signingKey
+                );
+              }}
+            >
+              With hash artifacts
+            </Button>
+            <Button
+              variant='text'
+              onClick={() => {
+                handleSignTypedData(
+                  { typedData: makeUnsupportedTypedData() },
+                  signingKey
+                );
+              }}
+            >
+              Unsupported type (error)
             </Button>
           </div>
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,6 @@ import {
   CLValueTuple2,
   ContractCallBuilder,
   Conversions,
-  HexBytes,
   Key,
   KeyAlgorithm,
   KeyTypeID,

--- a/src/wallet-service.tsx
+++ b/src/wallet-service.tsx
@@ -43,7 +43,7 @@ export type SignTypedDataParams = {
   };
 };
 
-type EIP712HashArtifacts = {
+export type EIP712HashArtifacts = {
   domainTypeString?: string;
   domain?: Record<string, unknown>;
   domainSeparator?: string;

--- a/src/wallet-service.tsx
+++ b/src/wallet-service.tsx
@@ -29,6 +29,39 @@ type WalletStorageState = {
   publicKey: string | null;
 };
 
+export type SignTypedDataParams = {
+  typedData: {
+    domain: Record<string, unknown>;
+    types: Record<string, Array<{ name: string; type: string }>>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  };
+  options?: {
+    domainTypes?: Array<{ name: string; type: string }>;
+    returnHashArtifacts?: boolean;
+    rejectUnknownFields?: boolean;
+  };
+};
+
+type EIP712HashArtifacts = {
+  domainTypeString?: string;
+  domain?: Record<string, unknown>;
+  domainSeparator?: string;
+  canonicalTypeString?: string;
+  typeHash?: string;
+  structHash?: string;
+};
+
+export type SignTypedDataResult = {
+  cancelled: boolean;
+  signature: string | null;
+  digest: string | null;
+  publicKey: string | null;
+  error: string | null;
+  errorCode?: string;
+  hashArtifacts?: EIP712HashArtifacts;
+};
+
 type WalletService = {
   logs: [string, object][];
   log: (msg: string, payload?: any) => void;
@@ -47,6 +80,10 @@ type WalletService = {
   ) => Promise<
     { cancelled: true } | { cancelled: false; signature: Uint8Array }
   >;
+  signTypedData: (
+    params: SignTypedDataParams,
+    accountPublicKey: string
+  ) => Promise<SignTypedDataResult | undefined>;
   decryptMessage: (
     message: string,
     signingPublicKeyHex: string
@@ -284,6 +321,11 @@ export const WalletServiceProvider = props => {
     return getCasperWalletInstance().signMessage(message, accountPublicKey);
   };
 
+  const signTypedData = async (
+    params: SignTypedDataParams,
+    accountPublicKey: string
+  ) => getCasperWalletInstance().signTypedData(params, accountPublicKey);
+
   const decryptMessage = async (message: string, accountPublicKey: string) => {
     return getCasperWalletInstance().decryptMessage(message, accountPublicKey);
   };
@@ -323,6 +365,7 @@ export const WalletServiceProvider = props => {
     switchAccount: switchAccount,
     sign: sign,
     signMessage: signMessage,
+    signTypedData,
     decryptMessage,
     disconnect: disconnect,
     isSiteConnected: isSiteConnected,


### PR DESCRIPTION
## Summary

Adds an **EIP-712 SIGNATURE REQUEST SCENARIOS** section to the playground so the wallet's new `signTypedData` flow can be exercised manually. This is the dApp end of epic WALLET-1250.

Closes WALLET-1254.

## What's added

**`src/wallet-service.tsx`**
- Exported types `SignTypedDataParams`, `SignTypedDataResult` (+ `EIP712HashArtifacts`), mirroring the canonical provider contract.
- Thin `signTypedData(params, accountPublicKey)` wrapper over `getCasperWalletInstance().signTypedData(...)`, wired into the `WalletService` context (mirrors `signMessage`).

**`src/App.tsx`**
- `makePermitTypedData()` / `makeUnsupportedTypedData()` sample payload factories (Permit example from PR #155).
- `handleSignTypedData` handler that branches on the result envelope: `cancelled` → alert, `error`/`errorCode` → alert, success → on-screen log (`signature`, `digest`, `publicKey`, `hashArtifacts`), unexpected → `.catch` alert.
- New section with 4 buttons: **Sign Typed Data (Permit)**, **Sign Typed Data (specify signing key)**, **With hash artifacts** (`returnHashArtifacts: true`), **Unsupported type (error)** (`bytes16` → `UNSUPPORTED_TYPE`).
- Incidental cleanup: removed the now-unused `HexBytes` import from `App.tsx` and `utils.ts`.

## Notes

- The provider method is **forward-looking** — the extension may not expose `signTypedData` yet; the playground types globals loosely so the call compiles and ships ahead of the extension. Manual browser testing will happen once the wallet is updated.
- `SignTypedDataResult` is intentionally a flat struct returning `Promise<SignTypedDataResult | undefined>` — this mirrors the real provider contract (casper-wallet-sdk docs / casper-click-websdk PR #155) verbatim, rather than the discriminated-union shape used by `sign`/`signMessage`.
- No unit tests: the playground has none by design. The gate is `npm run tsc` (passes clean).

## Epic context

dApp end of WALLET-1250: core (casper-wallet-core PR #41) → SDK docs (casper-wallet-sdk PR #18) → playground (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)