### PR TITLE
refactor(eip712): align signTypedData onto signTypedDataEIP712 convention

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ function App() {
     disconnect,
     sign,
     signMessage,
-    signTypedData,
+    signTypedDataEIP712,
     switchAccount,
     getVersion,
     isSiteConnected,
@@ -260,11 +260,11 @@ function App() {
       });
   };
 
-  const handleSignTypedData = (
+  const handleSignTypedDataEIP712 = (
     params: SignTypedDataParams,
     accountPublicKey: string
   ) => {
-    signTypedData(params, accountPublicKey)
+    signTypedDataEIP712(params, accountPublicKey)
       .then(res => {
         if (!res || res.cancelled) {
           alert('Sign cancelled');
@@ -1080,7 +1080,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
             <Button
               variant='text'
               onClick={() => {
-                handleSignTypedData({ typedData: makePermitTypedData() }, signingKey);
+                handleSignTypedDataEIP712({ typedData: makePermitTypedData() }, signingKey);
               }}
             >
               Sign Typed Data (Permit)
@@ -1094,7 +1094,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
                   return;
                 }
 
-                handleSignTypedData({ typedData: makePermitTypedData() }, key);
+                handleSignTypedDataEIP712({ typedData: makePermitTypedData() }, key);
               }}
             >
               Sign Typed Data (specify signing key)
@@ -1102,7 +1102,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
             <Button
               variant='text'
               onClick={() => {
-                handleSignTypedData(
+                handleSignTypedDataEIP712(
                   {
                     typedData: makePermitTypedData(),
                     options: { returnHashArtifacts: true }
@@ -1116,7 +1116,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
             <Button
               variant='text'
               onClick={() => {
-                handleSignTypedData(
+                handleSignTypedDataEIP712(
                   { typedData: makeUnsupportedTypedData() },
                   signingKey
                 );

--- a/src/wallet-service.tsx
+++ b/src/wallet-service.tsx
@@ -80,7 +80,7 @@ type WalletService = {
   ) => Promise<
     { cancelled: true } | { cancelled: false; signature: Uint8Array }
   >;
-  signTypedData: (
+  signTypedDataEIP712: (
     params: SignTypedDataParams,
     accountPublicKey: string
   ) => Promise<SignTypedDataResult | undefined>;
@@ -321,10 +321,10 @@ export const WalletServiceProvider = props => {
     return getCasperWalletInstance().signMessage(message, accountPublicKey);
   };
 
-  const signTypedData = async (
+  const signTypedDataEIP712 = async (
     params: SignTypedDataParams,
     accountPublicKey: string
-  ) => getCasperWalletInstance().signTypedData(params, accountPublicKey);
+  ) => getCasperWalletInstance().signTypedDataEIP712(params, accountPublicKey);
 
   const decryptMessage = async (message: string, accountPublicKey: string) => {
     return getCasperWalletInstance().decryptMessage(message, accountPublicKey);
@@ -365,7 +365,7 @@ export const WalletServiceProvider = props => {
     switchAccount: switchAccount,
     sign: sign,
     signMessage: signMessage,
-    signTypedData,
+    signTypedDataEIP712,
     decryptMessage,
     disconnect: disconnect,
     isSiteConnected: isSiteConnected,


### PR DESCRIPTION
## Summary

Aligns the playground's EIP-712 wrapper/handler functions and its SDK call onto the cross-repo `…TypedDataEIP712…` naming convention (the `EIP712` token inserted immediately after the `TypedData` segment).

Pure, behavior-preserving rename — `tsc` clean, `react-scripts build` compiles successfully.

## Changes

- `src/wallet-service.tsx`: local wrapper `signTypedData` → `signTypedDataEIP712` (interface field, declaration, returned-object key) and the SDK call `getCasperWalletInstance().signTypedData(...)` → `.signTypedDataEIP712(...)`.
- `src/App.tsx`: destructured `signTypedData` → `signTypedDataEIP712`; `handleSignTypedData` → `handleSignTypedDataEIP712` (declaration + 4 call sites).

## Left unchanged (by design)

- Local type names `SignTypedDataParams`, `SignTypedDataResult`, `EIP712HashArtifacts` (mirrors the core decision to leave type names alone).
- `getActiveKeySupports` / `getActivePublicKeySupports` (no `TypedData` token).

## Runtime dependency on casper-wallet

The renamed call `.signTypedDataEIP712()` resolves only against a `casper-wallet` extension build whose injected SDK exposes the renamed method. This PR must land together with (or after) the matching `casper-wallet` rename.

## Part of cross-repo effort

`casper-wallet-core` (PR #47) → **this** → `casper-wallet` → `casper-wallet-mobile`.
