### PR TITLE
refactor(eip712): rename signTypedDataEIP712 provider method back to signTypedData

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
     disconnect,
     sign,
     signMessage,
-    signTypedDataEIP712,
+    signTypedData,
     switchAccount,
     getVersion,
     isSiteConnected,
@@ -333,11 +333,11 @@ function App() {
       });
   };
 
-  const handleSignTypedDataEIP712 = (
+  const handleSignTypedData = (
     params: SignTypedDataParams,
     accountPublicKey: string
   ) => {
-    signTypedDataEIP712(params, accountPublicKey)
+    signTypedData(params, accountPublicKey)
       .then(res => {
         if (!res || res.cancelled) {
           alert('Sign cancelled');
@@ -1153,7 +1153,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
             <Button
               variant='text'
               onClick={() => {
-                handleSignTypedDataEIP712(
+                handleSignTypedData(
                   { typedData: makePermitTypedData(signingKey) },
                   signingKey
                 );
@@ -1164,7 +1164,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
             <Button
               variant='text'
               onClick={() => {
-                handleSignTypedDataEIP712(
+                handleSignTypedData(
                   {
                     typedData: makeTransferWithAuthorizationTypedData(signingKey),
                     options: { returnHashArtifacts: true }
@@ -1184,7 +1184,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
                   return;
                 }
 
-                handleSignTypedDataEIP712(
+                handleSignTypedData(
                   { typedData: makePermitTypedData(key) },
                   key
                 );
@@ -1195,7 +1195,7 @@ Decrypted message - ${decryptedResp.decryptedMessage}
             <Button
               variant='text'
               onClick={() => {
-                handleSignTypedDataEIP712(
+                handleSignTypedData(
                   { typedData: makeUnsupportedTypedData() },
                   signingKey
                 );

--- a/src/wallet-service.tsx
+++ b/src/wallet-service.tsx
@@ -80,7 +80,7 @@ type WalletService = {
   ) => Promise<
     { cancelled: true } | { cancelled: false; signature: Uint8Array }
   >;
-  signTypedDataEIP712: (
+  signTypedData: (
     params: SignTypedDataParams,
     accountPublicKey: string
   ) => Promise<SignTypedDataResult | undefined>;
@@ -321,10 +321,10 @@ export const WalletServiceProvider = props => {
     return getCasperWalletInstance().signMessage(message, accountPublicKey);
   };
 
-  const signTypedDataEIP712 = async (
+  const signTypedData = async (
     params: SignTypedDataParams,
     accountPublicKey: string
-  ) => getCasperWalletInstance().signTypedDataEIP712(params, accountPublicKey);
+  ) => getCasperWalletInstance().signTypedData(params, accountPublicKey);
 
   const decryptMessage = async (message: string, accountPublicKey: string) => {
     return getCasperWalletInstance().decryptMessage(message, accountPublicKey);
@@ -365,7 +365,7 @@ export const WalletServiceProvider = props => {
     switchAccount: switchAccount,
     sign: sign,
     signMessage: signMessage,
-    signTypedDataEIP712,
+    signTypedData,
     decryptMessage,
     disconnect: disconnect,
     isSiteConnected: isSiteConnected,


### PR DESCRIPTION
## Summary

Aligns the playground onto the wallet provider method renamed back to `signTypedData`.

The wallet provider exposes the typed-data signing method as `signTypedData` again (reverting the `signTypedDataEIP712` name). This updates the playground's SDK call and its local wrappers to match.

## Changes

- `wallet-service.tsx` — `getCasperWalletInstance().signTypedData(...)`, the service interface member and the local `signTypedData` wrapper.
- `App.tsx` — local `signTypedData` wrapper usage and the `handleSignTypedData` handler.

## Verification

- `tsc --noEmit` clean